### PR TITLE
Use PROJ 6 API to work also with Rtools42 5355.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,3 +1,3 @@
-## from Tomas, uses P4 API so verify on toolchain updates
+## from Tomas, uses P6 API so verify on toolchain updates
 PKG_LIBS = -lproj -lsqlite3 -lcurl -ltiff -ljpeg -lrtmp -lssl -lssh2 -lgcrypt -lcrypto -lgdi32 -lz -lzstd -lwebp -llzma -lgdi32 -lcrypt32 -lidn2 -lunistring -liconv -lgpg-error -lws2_32 -lwldap32 -lwinmm -lstdc++
-PKG_CPPFLAGS = -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1
+PKG_CPPFLAGS = -DUSE_PROJ6_API=1


### PR DESCRIPTION
This fixes the build for Rtools 42 5355, the current Rtools used with R 4.2.2.