### PR TITLE
Prepare for a future version of libcurl on Windows.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,3 +1,3 @@
 ## from Tomas, uses P6 API so verify on toolchain updates
-PKG_LIBS = -lproj -lsqlite3 -lcurl -ltiff -ljpeg -lrtmp -lssl -lssh2 -lgcrypt -lcrypto -lgdi32 -lz -lzstd -lwebp -llzma -lgdi32 -lcrypt32 -lidn2 -lunistring -liconv -lgpg-error -lws2_32 -lwldap32 -lwinmm -lstdc++
+PKG_LIBS = -lproj -lsqlite3 -lcurl -lbcrypt -ltiff -ljpeg -lrtmp -lssl -lssh2 -lgcrypt -lcrypto -lgdi32 -lz -lzstd -lwebp -llzma -lgdi32 -lcrypt32 -lidn2 -lunistring -liconv -lgpg-error -lws2_32 -lwldap32 -lwinmm -lstdc++
 PKG_CPPFLAGS = -DUSE_PROJ6_API=1


### PR DESCRIPTION
A future version of libcurl in MXE/Rtools43 will require bcrypt, so add it to the linking list. This will work also with current Rtools43 and Rtools42, because bcrypt is available.