### PR TITLE
Prepare for upcoming release of Rtools43: fix linking of curl and webp.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,3 +1,4 @@
 ## from Tomas, uses P6 API so verify on toolchain updates
-PKG_LIBS = -lproj -lsqlite3 -lcurl -ltiff -ljpeg -lrtmp -lssl -lssh2 -lgcrypt -lcrypto -lgdi32 -lz -lzstd -lwebp -llzma -lgdi32 -lcrypt32 -lidn2 -lunistring -liconv -lgpg-error -lws2_32 -lwldap32 -lwinmm -lstdc++
+LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+PKG_LIBS = -lproj -lsqlite3 -lcurl -lbcrypt -ltiff -ljpeg -lrtmp -lssl -lssh2 -lgcrypt -lcrypto -lgdi32 -lz -lzstd -lwebp $(LIBSHARPYUV) -llzma -lgdi32 -lcrypt32 -lidn2 -lunistring -liconv -lgpg-error -lws2_32 -lwldap32 -lwinmm -lstdc++
 PKG_CPPFLAGS = -DUSE_PROJ6_API=1


### PR DESCRIPTION
Changes needed for linking with an upcoming version of Rtools43 (5550). Linking of sharpyuv is conditional to work also with older versions of Rtools43 and with Rtools42.